### PR TITLE
Added additional channels to export to solve Issue #25

### DIFF
--- a/mdf42adx/CreateSampleMDF.py
+++ b/mdf42adx/CreateSampleMDF.py
@@ -24,7 +24,7 @@ def processFile(filename):
 
     signals = []
 
-    source = Source(source_type=Source.SOURCE_TOOL, bus_type=Source.BUS_TYPE_NONE, name="EngineControlUnit", path="Powertrain", comment="Generated" )
+    source = Source(source_type=Source.SOURCE_TOOL, bus_type=Source.BUS_TYPE_NONE, name="EngineControlUnit", path="PT_CAN.Powertrain", comment="Generated" )
 
     # Generate vehicle RPM signal
     rpm_amplitude = 500


### PR DESCRIPTION
Solves Issue #25 
Unfortunately there is no easy way to get the bus source - data from different dataloggers has different formats.
Instead of pre-processing this information, instead we are extracting three different values:

channel_group_acq_name
acq_source_name
acq_source_path

The channel group acq_name is the frame name. acq_source is filled differently depending on the logging tool but it should contain a bus identifier.