### PR TITLE
Handling of large files

### DIFF
--- a/mdf42adx/DecodeCSV.py
+++ b/mdf42adx/DecodeCSV.py
@@ -1,0 +1,47 @@
+from asammdf import MDF
+from asammdf.blocks import v4_constants as v4c
+import csv
+import gzip
+import os
+import time 
+import multiprocessing as mp
+from DecodeUtils import getSource, extractSignalsByType
+
+def processSignalAsCSV(counter, channel_group_acq_name, acq_source_name, acq_source_path, signal, uuid, targetdir, basename):
+    start_signal_time = time.time()
+    print(f"Processing signal {counter}: {signal.name} with type {signal.samples.dtype}")   
+    numericSignals, stringSignals = extractSignalsByType(signal)
+
+    os.makedirs(targetdir, exist_ok=True)
+
+    # open the file in the write mode
+    with gzip.open(os.path.join(targetdir, f"{uuid}-{counter}.csv.gz"), 'wt') as csvFile:
+
+        writer = csv.writer(csvFile)
+        writer.writerow(["source_uuid", "name", "unit", "timestamp", "value", "value_string", "source", "channel_group_acq_name", "acq_source_name", "acq_source_path", "source_type", "bus_type"])                
+                        
+        # Iterate on the entries for the signal
+
+        for indx in range(0, len(signal.timestamps)):
+
+            writer.writerow(
+                [
+                    str(uuid),
+                    signal.name, 
+                    signal.unit, 
+                    signal.timestamps[indx],
+                    numericSignals[indx],
+                    stringSignals[indx],
+                    signal.source.name,
+                    channel_group_acq_name,
+                    acq_source_name,
+                    acq_source_path,                    
+                    v4c.SOURCE_TYPE_TO_STRING[signal.source.source_type],
+                    v4c.BUS_TYPE_TO_STRING[signal.source.bus_type],
+                ]
+            )
+
+    csvFile.close()
+    
+    end_signal_time = time.time() - start_signal_time
+    print(f"Signal {counter}: {signal.name} with {len(signal.timestamps)} entries took {end_signal_time}")

--- a/mdf42adx/DecodeCSV.py
+++ b/mdf42adx/DecodeCSV.py
@@ -7,41 +7,59 @@ import time
 import multiprocessing as mp
 from DecodeUtils import getSource, extractSignalsByType
 
-def processSignalAsCSV(counter, channel_group_acq_name, acq_source_name, acq_source_path, signal, uuid, targetdir, basename):
+def processSignalAsCsv(counter, filename, signalMetadata, uuid, targetdir, blacklistedSignals):
+
     start_signal_time = time.time()
-    print(f"Processing signal {counter}: {signal.name} with type {signal.samples.dtype}")   
-    numericSignals, stringSignals = extractSignalsByType(signal)
+    print(f"pid {os.getpid()}: Launched task signal {counter}: {signalMetadata['name']}")
 
-    os.makedirs(targetdir, exist_ok=True)
+    if signalMetadata["name"] in blacklistedSignals:
+        return (f"pid {os.getpid()}", False, counter, f">>> Skipped: {signalMetadata}")
 
-    # open the file in the write mode
-    with gzip.open(os.path.join(targetdir, f"{uuid}-{counter}.csv.gz"), 'wt') as csvFile:
 
-        writer = csv.writer(csvFile)
-        writer.writerow(["source_uuid", "name", "unit", "timestamp", "value", "value_string", "source", "channel_group_acq_name", "acq_source_name", "acq_source_path", "source_type", "bus_type"])                
-                        
-        # Iterate on the entries for the signal
 
-        for indx in range(0, len(signal.timestamps)):
+    # Get the signal group and channel index to load that specific signal ONLY
+    group_index = signalMetadata["group_index"]
+    channel_index = signalMetadata["channel_index"]
 
-            writer.writerow(
-                [
-                    str(uuid),
-                    signal.name, 
-                    signal.unit, 
-                    signal.timestamps[indx],
-                    numericSignals[indx],
-                    stringSignals[indx],
-                    signal.source.name,
-                    channel_group_acq_name,
-                    acq_source_name,
-                    acq_source_path,                    
-                    v4c.SOURCE_TYPE_TO_STRING[signal.source.source_type],
-                    v4c.BUS_TYPE_TO_STRING[signal.source.bus_type],
-                ]
-            )
+    # Open the MDF file and select a single signal
+    mdf = MDF(filename)          
+    signals = mdf.select([(None, group_index, channel_index)])        
+    
+    print(f"pid {os.getpid()}: MDF file open signal {counter}: {signalMetadata['name']} - {filename} opened group {group_index}, channel {channel_index})")
+    
+    for signal in signals:
+        print(f"pid {os.getpid()}: Processing signal {counter}: {signal.name} group index {group_index} channel index {channel_index} with type {signal.samples.dtype}")   
 
-    csvFile.close()
+        # open the file in the write mode
+        with gzip.open(os.path.join(targetdir, f"{uuid}-{counter}.csv.gz"), 'wt') as csvFile:
+
+            channel_group_acq_name, acq_source_name, acq_source_path = getSource(mdf, signal)    
+            numericSignals, stringSignals = extractSignalsByType(signal)
+
+            writer = csv.writer(csvFile)
+            writer.writerow(["source_uuid", "name", "unit", "timestamp", "value", "value_string", "source", "channel_group_acq_name", "acq_source_name", "acq_source_path", "source_type", "bus_type"])                
+                            
+            # Iterate on the entries for the signal
+            for indx in range(0, len(signal.timestamps)):
+
+                writer.writerow(
+                    [
+                        str(uuid),
+                        signal.name, 
+                        signal.unit, 
+                        signal.timestamps[indx],
+                        numericSignals[indx],
+                        stringSignals[indx],
+                        signal.source.name,
+                        channel_group_acq_name,
+                        acq_source_name,
+                        acq_source_path,                    
+                        v4c.SOURCE_TYPE_TO_STRING[signal.source.source_type],
+                        v4c.BUS_TYPE_TO_STRING[signal.source.bus_type],
+                    ]
+                )
+
+        csvFile.close()
     
     end_signal_time = time.time() - start_signal_time
     print(f"Signal {counter}: {signal.name} with {len(signal.timestamps)} entries took {end_signal_time}")

--- a/mdf42adx/DecodeParquet.py
+++ b/mdf42adx/DecodeParquet.py
@@ -1,0 +1,87 @@
+from asammdf import MDF
+from asammdf.blocks import v4_constants as v4c
+from datetime import datetime, timedelta
+import time 
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+import os
+from DecodeUtils import getSource, extractSignalsByType
+
+
+
+def processSignalAsParquet(counter, filename, signalMetadata, uuid, targetdir, blacklistedSignals):
+    '''
+        Creates a parquet export with the structure that we will import into ADX.
+        There are three important pieces of information for time analysis of automotive signals
+            - The signal itself, which might be a record, numeric or string
+            - The frame, which might contain multiple signals
+            - The bus (some signals might be avaialble on multiple buses such as CAN and LIN)
+
+        Additional information that is relevant for analytis:
+            - The source ECU, as some analysis are related to specific Electronic Control Units.
+            - The type of BUS, as some analysis are specific to CAN, LIN or ETH.
+
+    '''
+
+    start_signal_time = time.time()
+    print(f"pid {os.getpid()}: Launched task signal {counter}: {signalMetadata['name']}")
+
+    try:        
+
+        if signalMetadata["name"] in blacklistedSignals:
+            return (f"pid {os.getpid()}", False, counter, f">>> Skipped: {signalMetadata}")
+
+        # Get the signal group and channel index to load that specific signal ONLY
+        group_index = signalMetadata["group_index"]
+        channel_index = signalMetadata["channel_index"]
+
+        # Open the MDF file and select a single signal
+        mdf = MDF(filename)          
+        signals = mdf.select([(None, group_index, channel_index)])        
+        
+        print(f"pid {os.getpid()}: MDF file open signal {counter}: {signalMetadata['name']} - {filename} opened group {group_index}, channel {channel_index})")
+        
+        for signal in signals:
+            print(f"pid {os.getpid()}: Processing signal {counter}: {signal.name} group index {group_index} channel index {channel_index} with type {signal.samples.dtype}")   
+            
+            try:
+                channel_group_acq_name, acq_source_name, acq_source_path = getSource(mdf, signal)    
+                numericSignals, stringSignals = extractSignalsByType(signal)
+                
+                table = pa.table (
+                    {                   
+                        "source_uuid": np.full(len(signal.timestamps), str(uuid), dtype=object),
+                        "name": np.full(len(signal.timestamps), signal.name, dtype=object),
+                        "unit": np.full(len(signal.timestamps), signal.unit, dtype=object),
+                        "timestamp": signal.timestamps,
+                        "timestamp_diff": np.append(0, np.diff(signal.timestamps)),
+                        "value": numericSignals,
+                        "value_string": stringSignals,
+                        "source": np.full(len(signal.timestamps), signal.source.name, dtype=object),
+                        "channel_group_acq_name": np.full(len(signal.timestamps), channel_group_acq_name, dtype=object),
+                        "acq_source_name": np.full(len(signal.timestamps), acq_source_name, dtype=object),
+                        "acq_source_path": np.full(len(signal.timestamps), acq_source_path, dtype=object),
+                        "source_type": np.full(len(signal.timestamps), v4c.SOURCE_TYPE_TO_STRING[signal.source.source_type], dtype=object),
+                        "bus_type": np.full(len(signal.timestamps), v4c.BUS_TYPE_TO_STRING[signal.source.bus_type], dtype=object)
+                    }
+                ) 
+                pq.write_to_dataset(table, root_path=targetdir, compression="snappy")                
+                
+            except Exception as e:
+                return (f"pid {os.getpid()}", False, counter, f"Signal {counter}: {signal.name} with {len(signal.timestamps)} failed: {str(e)}")
+
+            
+            end_signal_time = time.time() - start_signal_time        
+
+        return (f"pid {os.getpid()}", True, counter, f"Processed signal {counter}: {signal.name} with {len(signal.timestamps)} entries in {end_signal_time}")       
+    
+    except Exception as e:
+        return (f"pid {os.getpid()}", False, counter, f"Signal {counter}: {signal.name} with {len(signal.timestamps)} failed: {str(e)}")
+    
+    finally:
+        print(f"pid {os.getpid()}: Closed signal {counter}: {signalMetadata['name']} MDF file {filename} closed")
+        mdf.close()
+        del signals
+        del mdf
+        print(f"pid {os.getpid()}: Finished task signal {counter}: {signalMetadata['name']}")

--- a/mdf42adx/DecodeUtils.py
+++ b/mdf42adx/DecodeUtils.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+def getSource(mdf, signal):
+    '''
+        Extracts the source information from the MDF-4 file for a given signal
+    '''
+
+    try: 
+        channel_group_acq_name = mdf.groups[signal.group_index].channel_group.acq_name
+    except:
+        channel_group_acq_name = ""
+
+    try: 
+        acq_source_name = mdf.groups[signal.group_index].channel_group.acq_source.name
+    except:
+        acq_source_name = ""
+
+    try:
+        acq_source_path = mdf.groups[signal.group_index].channel_group.acq_source.path
+    except:
+        acq_source_path = ""
+
+    return channel_group_acq_name, acq_source_name, acq_source_path
+
+def extractSignalsByType(signal):
+    '''
+        Extracts the signals from the MDF-4 file and converts them to a numeric or string representation
+        Takes into consideration numbers, strings and records (rendered as a string) 
+    '''   
+
+    if np.issubdtype(signal.samples.dtype, np.record):
+        numericSignals = np.full(len(signal.timestamps), dtype=np.double, fill_value=0)      
+        stringSignals = [record.pprint() for record in signal.samples]
+
+    elif np.issubdtype(signal.samples.dtype, np.number):
+        numericSignals = signal.samples.astype(np.double)
+        stringSignals = np.empty(len(signal.timestamps), dtype=str) 
+
+    else:
+        numericSignals = np.full(len(signal.timestamps), dtype=np.double, fill_value=0)            
+        stringSignals = signal.samples.astype(str)
+    return numericSignals,stringSignals

--- a/mdf42adx/PrepareMDF4FileForADX.py
+++ b/mdf42adx/PrepareMDF4FileForADX.py
@@ -4,35 +4,45 @@ import argparse
 from asammdf import MDF
 from asammdf.blocks import v4_constants as v4c
 import csv
-from datetime import datetime, timedelta
+from datetime import datetime
 import gzip
 import json
 import os
-import pandas as pd
 from   pathlib import Path
 import time 
 import multiprocessing as mp
-import numpy as np
+from multiprocessing import get_context
 import uuid
-import pyarrow as pa
-import pyarrow.parquet as pq
+from DecodeParquet import processSignalAsParquet
+from DecodeUtils import getSource
 
 
-def dumpSignals(mdf):
-    '''Iterates over all signals and prints them to the console'''    
+def dumpSignals(filename):
+    '''Iterates over all signals and prints them to the console'''
+
+    mdf = MDF(filename)
 
     for counter, signal in enumerate(mdf.iter_channels()):
         channel_group_acq_name, acq_source_name, acq_source_path = getSource(mdf, signal)
         print(f"{signal.source.name}, {channel_group_acq_name}, {acq_source_name}, {acq_source_path}, {signal.name}, {signal.unit}, {v4c.SOURCE_TYPE_TO_STRING[signal.source.source_type]}, {v4c.BUS_TYPE_TO_STRING[signal.source.bus_type]}, {signal.group_index}, {signal.channel_index}")
 
+    mdf.close()
+    del mdf
+
     return counter
 
-def writeMetadata(basename, mdf, uuid, target, numberOfChunks):
-    '''Creates a JSON metadata file containing the signals description for the MDF-4 file'''
+def writeMetadata(filename, basename, uuid, target):
+    '''
+        Creates a JSON metadata file containing the signals description for the MDF-4 file
+    '''
+
+    mdf = MDF(filename)
 
     with open(os.path.join(target, f"{basename}-{uuid}.metadata.json"), 'w') as metadataFile:
         
         print(f"Writing metadata file {basename}-{uuid}")
+
+        signalNames = []
 
         metadata = {
             "name": basename,
@@ -40,11 +50,9 @@ def writeMetadata(basename, mdf, uuid, target, numberOfChunks):
             "preparation_startDate": str(datetime.utcnow()),
             "signals": [],
             "comments": mdf.header.comment,
-            "numberOfChunks": numberOfChunks
         }
 
-
-        for signal in mdf.iter_channels(raw=True):
+        for signal in mdf.iter_channels():
 
             channel_group_acq_name, acq_source_name, acq_source_path = getSource(mdf, signal)
 
@@ -63,217 +71,117 @@ def writeMetadata(basename, mdf, uuid, target, numberOfChunks):
                     "bus_type": v4c.BUS_TYPE_TO_STRING[signal.source.bus_type],
                 }          
             )
-
         metadataFile.write(json.dumps(metadata))
        
-    metadataFile.close()
+    print(f"Finished writing metadata file {basename}-{uuid} with {len(metadata['signals'])}")
 
-def writeParquet(basename, mdf, uuid, target):       
+    mdf.close()
+
+    del mdf
+
+    return metadata["signals"]
+
+
+def log_result(result):
+    print(f"{result}")
+
+def log_error(error):
+    print(f"{error}")
+
+def processSignals(filename, basename, uuid, target, signalsMetadata, blacklistedSignals, method):
     '''
-        Writes the MDF-4 file to a parquet file
-    '''
-
-    targetdir = os.path.join(target, f"{basename}-{uuid}")
-
-    # Create a pool of worker processes
-    pool = mp.Pool(mp.cpu_count())
-        
-    # Iterate over the signals contained in the MDF-4 file
-    result = []
-    for counter, signal in enumerate(mdf.iter_channels(copy_master=False)):                       
-        
-        channel_group_acq_name, acq_source_name, acq_source_path = getSource(mdf, signal)
-        # Apply the processSignal function to each signal asynchronously
-        #processSignal(counter, channel_group_acq_name, acq_source_name, acq_source_path, signal, uuid, targetdir)        
-        result.append(pool.apply_async(processSignal, args=(counter, channel_group_acq_name, acq_source_name, acq_source_path, signal, uuid, targetdir)))
-    
-    # Wait for all processes to finish
-    for r in result:
-        r.wait()
-      
-    return counter
-
-
-def processSignal(counter, channel_group_acq_name, acq_source_name, acq_source_path, signal, uuid, targetdir):
-    '''
-        Creates a parquet export with the structure that we will import into ADX.
-        There are three important pieces of information for time analysis of automotive signals
-            - The signal itself, which might be a record, numeric or string
-            - The frame, which might contain multiple signals
-            - The bus (some signals might be avaialble on multiple buses such as CAN and LIN)
-
-        Additional information that is relevant for analytis:
-            - The source ECU, as some analysis are related to specific Electronic Control Units.
-            - The type of BUS, as some analysis are specific to CAN, LIN or ETH.
-
-    '''
-    start_signal_time = time.time()
-    print(f"Processing signal {counter}: {signal.name} with type {signal.samples.dtype}")   
-
-    try:
-        numericSignals, stringSignals = extractSignalsByType(signal)
-        
-        table = pa.table (
-            {                   
-                "source_uuid": np.full(len(signal.timestamps), str(uuid), dtype=object),
-                "name": np.full(len(signal.timestamps), signal.name, dtype=object),
-                "unit": np.full(len(signal.timestamps), signal.unit, dtype=object),
-                "timestamp": signal.timestamps,
-                "timestamp_diff": np.append(0, np.diff(signal.timestamps)),
-                "value": numericSignals,
-                "value_string": stringSignals,
-                "source": np.full(len(signal.timestamps), signal.source.name, dtype=object),
-                "channel_group_acq_name": np.full(len(signal.timestamps), channel_group_acq_name, dtype=object),
-                "acq_source_name": np.full(len(signal.timestamps), acq_source_name, dtype=object),
-                "acq_source_path": np.full(len(signal.timestamps), acq_source_path, dtype=object),
-                "source_type": np.full(len(signal.timestamps), v4c.SOURCE_TYPE_TO_STRING[signal.source.source_type], dtype=object),
-                "bus_type": np.full(len(signal.timestamps), v4c.BUS_TYPE_TO_STRING[signal.source.bus_type], dtype=object)
-            }
-        ) 
-        pq.write_to_dataset(table, root_path=targetdir)
-
-        del table
-        
-    except Exception as e:
-        print(f"Signal {counter}: {signal.name} with {len(signal.timestamps)} failed: {e}")    
-
-    end_signal_time = time.time() - start_signal_time
-    print(f"Signal {counter}: {signal.name} with {len(signal.timestamps)} entries took {end_signal_time}")
-
-
-def getSource(mdf, signal):
-    '''
-        Extracts the source information from the MDF-4 file for a given signal
-    '''
-
-    try: 
-        channel_group_acq_name = mdf.groups[signal.group_index].channel_group.acq_name
-    except:
-        channel_group_acq_name = ""
-
-    try: 
-        acq_source_name = mdf.groups[signal.group_index].channel_group.acq_source.name
-    except:
-        acq_source_name = ""
-
-    try:
-        acq_source_path = mdf.groups[signal.group_index].channel_group.acq_source.path
-    except:
-        acq_source_path = ""
-
-    return channel_group_acq_name, acq_source_name, acq_source_path
-
-def extractSignalsByType(signal):
-    '''
-        Extracts the signals from the MDF-4 file and converts them to a numeric or string representation
-        Takes into consideration numbers, strings and records (rendered as a string) 
+        Writes the MDF-4 file to a parquet file.
+        Each signal will be written to a separate file in parallel
     '''   
 
-    if np.issubdtype(signal.samples.dtype, np.record):
-        numericSignals = np.full(len(signal.timestamps), dtype=np.double, fill_value=0)      
-        stringSignals = [record.pprint() for record in signal.samples]
+    doParallel = True
+    okSignals = []
+    nokSignals = []
+    timeoutSignals = []
+    
+    targetdir = os.path.join(target, f"{basename}-{uuid}")
+    
+    if (doParallel):
+        try:
+            # Create a pool of worker processes with all available CPUs
+            pool = get_context("spawn").Pool(mp.cpu_count()-1)
 
-    elif np.issubdtype(signal.samples.dtype, np.number):
-        numericSignals = signal.samples.astype(np.double)
-        stringSignals = np.empty(len(signal.timestamps), dtype=str) 
+            # Iterate over the signals contained in the MDF-4 file
+            results = []
+            for counter, signalMetadata in enumerate(signalsMetadata):
+                # Apply the processSignal function to each signal asynchronously
+                result = pool.apply_async(
+                    method, 
+                    args=(counter, filename, signalMetadata, uuid, targetdir, blacklistedSignals),
+                    callback=log_result,
+                    error_callback=log_error
+                )
+                results.append(result)
+
+            # All tasks have been submitted, no more tasks will be added to this pool.
+            pool.close()
+
+            # get the task result with a timeout defined as 3 minutes per signal.
+            # This is a blocking call, so we will check the results in the order in which the tasks are submitted
+            for counter, result in enumerate(results):
+                try:
+                    print(f"Waiting for value for {counter} - {signalsMetadata[counter]['name']}")
+                    value = result.get(timeout=60*3)                    
+                    okSignals.append( (signalsMetadata[counter], value))
+                except mp.TimeoutError as te:
+                    print(f"TimeoutError for {counter} - {signalsMetadata[counter]['name']}: {te}")
+                    timeoutSignals.append(signalsMetadata[counter])
+                    continue
+                except Exception as e:
+                    print(f"Exception for {counter} - {signalsMetadata[counter]['name']}: {e}")
+                    nokSignals.append(signalsMetadata[counter])
+                    continue
+
+        except Exception as e:
+            print(e)
+        finally:
+            print (f"Finished. Tasks total/ok/nok/timeout: {len(signalsMetadata)} / {len(okSignals)} / {len(nokSignals)} / {len(timeoutSignals)}")
+            print (f"NOK signals: {nokSignals}")
+            print (f"Timeout signals: {timeoutSignals}")
+            pool.terminate()
 
     else:
-        numericSignals = np.full(len(signal.timestamps), dtype=np.double, fill_value=0)            
-        stringSignals = signal.samples.astype(str)
-    return numericSignals,stringSignals
+        for counter, signalMetadata in enumerate(signalsMetadata):     
+            method(counter, filename, signalMetadata, uuid, targetdir)
 
-def writeCsv(basename, mdf, uuid, target):
-    '''    
-        Writes a gzipped CSV file using the uuid as name
-        It will write a file for each individual signal
-    '''
-
-    targetdir = os.path.join(target, f"{basename}-{uuid}")
-
-    # Iterate over the signals contained in the MDF-4 file
-    for counter, signal in enumerate(mdf.iter_channels(copy_master=False)):                     
-        # Apply the processSignal function to each signal asynchronously
-    
-        channel_group_acq_name, acq_source_name, acq_source_path = getSource(mdf, signal)
-        processSignalCSV(counter, channel_group_acq_name, acq_source_name, acq_source_path, signal, uuid, targetdir, basename)
-        
-    return counter
-
-def processSignalCSV(counter, channel_group_acq_name, acq_source_name, acq_source_path, signal, uuid, targetdir, basename):
-    start_signal_time = time.time()
-    print(f"Processing signal {counter}: {signal.name} with type {signal.samples.dtype}")   
-    numericSignals, stringSignals = extractSignalsByType(signal)
-
-    os.makedirs(targetdir, exist_ok=True)
-
-
-    # open the file in the write mode
-    with gzip.open(os.path.join(targetdir, f"{uuid}-{counter}.csv.gz"), 'wt') as csvFile:
-
-        writer = csv.writer(csvFile)
-        writer.writerow(["source_uuid", "name", "unit", "timestamp", "value", "value_string", "source", "channel_group_acq_name", "acq_source_name", "acq_source_path", "source_type", "bus_type"])                
-                        
-        # Iterate on the entries for the signal
-
-        for indx in range(0, len(signal.timestamps)):
-
-            try:
-                numericValue = float(signal.samples[indx])
-            except:
-                numericValue = "",
-
-            writer.writerow(
-                [
-                    str(uuid),
-                    signal.name, 
-                    signal.unit, 
-                    signal.timestamps[indx],
-                    numericSignals[indx],
-                    stringSignals[indx],
-                    signal.source.name,
-                    channel_group_acq_name,
-                    acq_source_name,
-                    acq_source_path,                    
-                    v4c.SOURCE_TYPE_TO_STRING[signal.source.source_type],
-                    v4c.BUS_TYPE_TO_STRING[signal.source.bus_type],
-                ]
-            )
-
-    csvFile.close()
-    
-    end_signal_time = time.time() - start_signal_time
-    print(f"Signal {counter}: {signal.name} with {len(signal.timestamps)} entries took {end_signal_time}")
+def readBlacklistedSignals():
+    return [
+    ]
 
 def processFile(filename):
     '''Processes a single MDF file.'''
 
     start_time = time.time()
-    mdf = MDF(filename)
-    numberOfChunks = 0
+    numberOfSignals = 0
 
     # If the argument is dump, show the signals
     if (args.dump):
-       numberOfChunks = dumpSignals(mdf)
+       numberOfSignals = dumpSignals(filename)
         
     # Otherwise export
     else:        
         basename = Path(filename).stem
-        file_uuid = uuid.uuid4()  
-        numberOfChunks = 0
+        file_uuid = uuid.uuid4()          
+
+        # Write a metadata file with all the file and signal information
+        signalsMetadata = writeMetadata(filename, basename, file_uuid, args.target)        
+        numberOfSignals = len(signalsMetadata)
 
         # Use the right method based on the format
         if (args.exportFormat == "parquet"):         
-            numberOfChunks = writeParquet(basename, mdf, file_uuid, args.target)
-        elif (args.exportFormat == "csv"):        
-            numberOfChunks = writeCsv(basename, mdf, file_uuid, args.target)        
+            processSignals(filename, basename, file_uuid, args.target, signalsMetadata, readBlacklistedSignals(), processSignalAsParquet)
+        if (args.exportFormat == "csv"):         
+            processSignals(filename, basename, file_uuid, args.target, signalsMetadata, readBlacklistedSignals(), processSignalAsCsv)
         else:
-            print("No export Format selected, use --format with parquet or csv")
-        
-        # Write an additional metadata file with all the signal information
-        writeMetadata(basename, mdf, file_uuid, args.target, numberOfChunks)
+            print("Incorrect format selected, use argument --format with parquet or csv")                
 
     end_time = time.time() - start_time
-    print (f"Processing {filename} took {end_time} and has {numberOfChunks} signals")
+    print (f"Processing {filename} took {end_time} and has {numberOfSignals} signals")
 
 def processDirectory(directoryname):
     '''Processes a complete directoy containing several MDF-4 files.'''


### PR DESCRIPTION
Fixed Issue #31 

Restructured the methods so the parallel processing spawns new processes. The MDF file is now opened and closed inside of the child process and opening the file only selects individual signals. This means that the processing of each signal is now done in an independent process.

Added logic also to timeout child processes that do not work properly - this can be improved as the current logic checks and blocks by process. New enhancement will be created to process the MDF files per channel group instead of per signal and to use a löibrary that supports timeouts per task.