### PR TITLE
Total number of entries in ALL signal for a given input file. Print total no. of entries at the end of decoding process

### DIFF
--- a/mdf42adx/DecodeCSV.py
+++ b/mdf42adx/DecodeCSV.py
@@ -64,4 +64,4 @@ def processSignalAsCsv(counter, filename, signalMetadata, uuid, targetdir, black
     end_signal_time = time.time() - start_signal_time
     mdf.close()
     
-    return (f"Signal {counter}: {decodedSignal.name} with {len(decodedSignal.timestamps)} entries took {end_signal_time}")
+    return (f"Signal {counter}: {decodedSignal.name} with {len(decodedSignal.timestamps)} entries took {end_signal_time}", len(decodedSignal.timestamps)) # Last position is here the no. of entries count - length will suffice to check no. of entries 

--- a/mdf42adx/DecodeParquet.py
+++ b/mdf42adx/DecodeParquet.py
@@ -83,14 +83,14 @@ def processSignalAsParquet(counter, filename, signalMetadata, uuid, targetdir, b
                 compression="snappy")                
             
         except Exception as e:
-            return (f"pid {os.getpid()}", False, counter, f"Signal {counter}: {decodedSignal.name} with {len(decodedSignal.timestamps)} failed: {str(e)}")
+            return (f"pid {os.getpid()}", False, counter, f"Signal {counter}: {decodedSignal.name} with {len(decodedSignal.timestamps)} failed: {str(e)}", 0) # Last position is here the no. of entries count - for failed signal this will be 0
         
         end_signal_time = time.time() - start_signal_time        
 
-        return (f"pid {os.getpid()}", True, counter, f"Processed signal {counter}: {decodedSignal.name} with {len(decodedSignal.timestamps)} entries in {end_signal_time}")       
+        return (f"pid {os.getpid()}", True, counter, f"Processed signal {counter}: {decodedSignal.name} with {len(decodedSignal.timestamps)} entries in {end_signal_time}", {len(decodedSignal.timestamps)}) # Last position is here the no. of entries count - length will suffice to check no. of entries 
     
     except Exception as e:
-        return (f"pid {os.getpid()}", False, counter, f"Signal {counter}: {decodedSignal.name} with {len(decodedSignal.timestamps)} failed: {str(e)}")
+        return (f"pid {os.getpid()}", False, counter, f"Signal {counter}: {decodedSignal.name} with {len(decodedSignal.timestamps)} failed: {str(e)}", 0) # Last position is here the no. of entries count - for failed signal this will be 0
     
     finally:
         mdf.close()


### PR DESCRIPTION
Added minor changes to output the total cumulative no. of entries in signals. This will help with the reconciliation of total entries in a raw files between Batch and ADX by using source_uuid as identifier. Made changes to the CSV as well.

modified:   DecodeCSV.py
modified:   DecodeParquet.py
modified:   PrepareMDF4FileForADX.py