### PR TITLE
Solved issue #67

### DIFF
--- a/mdf42adx/DecodeParquet.py
+++ b/mdf42adx/DecodeParquet.py
@@ -30,7 +30,6 @@ def processSignalAsParquet(counter, filename, signalMetadata, uuid, targetdir, b
     channel_index = signalMetadata["channel_index"]
     print(f"pid {os.getpid()}: Processing signal {counter}: {signal_name} group index {group_index} channel index {channel_index}") 
 
-
     try:        
         # Open the MDF file and select a single signal
         mdf = MDF(filename)     
@@ -45,51 +44,44 @@ def processSignalAsParquet(counter, filename, signalMetadata, uuid, targetdir, b
         decodedSignal = mdf.select(channels=[(None, group_index, channel_index)])[0]
         rawSignal = mdf.select(channels=[(None, group_index, channel_index)], raw=True)[0]
     
+        numberOfSamples = len(decodedSignal.timestamps)
 
-        try:
+        # If there are no samples, we report a success but with 0 samples
+        if (numberOfSamples == 0):              
+            return (f"pid {os.getpid()}", True, counter, f"Processed signal {counter}: {decodedSignal.name} - no samples in file", numberOfSamples)
 
-            numberOfSamples = len(decodedSignal.timestamps)
+        floatSignals, integerSignals, uint64Signals, stringSignals = extractSignalsByType(decodedSignal=decodedSignal, rawSignal=rawSignal)                       
 
-            # If there are no samples, we report a success but with 0 samples
-            if (numberOfSamples == 0):                
-                return (f"pid {os.getpid()}", True, counter, f"Processed signal {counter}: {decodedSignal.name} - no samples in file", numberOfSamples)
+        table = pa.table (
+            {                   
+                "source_uuid": np.full(numberOfSamples, str(uuid), dtype=object),
+                "group_index": np.full(numberOfSamples, group_index, dtype=np.int32),
+                "channel_index": np.full(numberOfSamples, channel_index, dtype=np.int32),
+                "name": np.full(numberOfSamples, decodedSignal.name, dtype=object),
+                "unit": np.full(numberOfSamples, decodedSignal.unit, dtype=object),
+                "timestamp": decodedSignal.timestamps,
+                "timestamp_diff": np.append(0, np.diff(decodedSignal.timestamps)),
+                "value": floatSignals,
+                "value_int": integerSignals,
+                "value_uint64": uint64Signals,
+                "value_string": stringSignals,
+                "valueRaw" : rawSignal.samples,
+            }
+        )             
 
+        # Escape all characters from the decodedSignal.name and use only alphanumeric and underscore for the basename
+        # This is to avoid issues with the basename_template and parquet
+        parquetFileName = re.sub(r"[^a-zA-Z0-9_]", "_", decodedSignal.name)
 
-            floatSignals, integerSignals, uint64Signals, stringSignals = extractSignalsByType(decodedSignal=decodedSignal, rawSignal=rawSignal)                       
-
-            table = pa.table (
-                {                   
-                    "source_uuid": np.full(numberOfSamples, str(uuid), dtype=object),
-                    "group_index": np.full(numberOfSamples, group_index, dtype=np.int32),
-                    "channel_index": np.full(numberOfSamples, channel_index, dtype=np.int32),
-                    "name": np.full(numberOfSamples, decodedSignal.name, dtype=object),
-                    "unit": np.full(numberOfSamples, decodedSignal.unit, dtype=object),
-                    "timestamp": decodedSignal.timestamps,
-                    "timestamp_diff": np.append(0, np.diff(decodedSignal.timestamps)),
-                    "value": floatSignals,
-                    "value_int": integerSignals,
-                    "value_uint64": uint64Signals,
-                    "value_string": stringSignals,
-                    "valueRaw" : rawSignal.samples,
-                }
-            )             
-
-            # Escape all characters from the decodedSignal.name and use only alphanumeric and underscore for the basename
-            # This is to avoid issues with the basename_template and parquet
-            parquetFileName = re.sub(r"[^a-zA-Z0-9_]", "_", decodedSignal.name)
-
-            pq.write_to_dataset(
-                table, 
-                root_path=targetdir,
-                basename_template=f"{group_index}-{channel_index}-{parquetFileName}-{{i}}.parquet",
-                use_threads=True,
-                compression="snappy")                
-            
-        except Exception as e:
-            return (f"pid {os.getpid()}", False, counter, f"Signal {counter}: {decodedSignal.name} with {len(decodedSignal.timestamps)} failed: {str(e)}", 0)
+        pq.write_to_dataset(
+            table, 
+            root_path=targetdir,
+            basename_template=f"{group_index}-{channel_index}-{parquetFileName}-{{i}}.parquet",
+            use_threads=True,
+            compression="snappy")                 
         
         end_signal_time = time.time() - start_signal_time        
-        
+
         return (f"pid {os.getpid()}", True, counter, f"Processed signal {counter}: {decodedSignal.name} with {len(decodedSignal.timestamps)} entries in {end_signal_time}", numberOfSamples)
     
     except Exception as e:

--- a/mdf42adx/MDF2AnalyticsFormatProcessing.py
+++ b/mdf42adx/MDF2AnalyticsFormatProcessing.py
@@ -65,9 +65,17 @@ def processSignals(filename, basename, uuid, target, signalsMetadata, blackliste
         # This is a blocking call, so we will check the results in the order in which the tasks are submitted
         for counter, result in enumerate(results):            
 
+
+
             try:
                 #print(f"Waiting for value for {counter} - {signalsMetadata[counter]['name']}")
-                value = result.get(timeout=60*6) # Wait for the value for 6 minutes, if it is not ready, it will probably never be                    
+                value = result.get(timeout=60*6) # Wait for the value for 6 minutes, if it is not ready, it will probably never be   
+
+                #Append the value to signalsMetadata json file
+                signalsMetadata[counter]["signal_decoded_status"] = value[1]
+                signalsMetadata[counter]["records_count"] = value[4]
+                signalsMetadata[counter]["message"] = value[3]
+                
                 finishedSignals.append(
                     {
                         "counter": counter,
@@ -81,10 +89,13 @@ def processSignals(filename, basename, uuid, target, signalsMetadata, blackliste
                     
                 log_completition( (len(finishedSignals) / numberOfSignals)*100 ) # Log the percentage of signals processed
                 
-
-
             except mp.TimeoutError as te:
                 print(f"TimeoutError for {counter} - {signalsMetadata[counter]['name']}: {te}")
+
+                signalsMetadata[counter]["signal_decoded_status"] = False
+                signalsMetadata[counter]["records_count"] = 0
+                signalsMetadata[counter]["message"] = f"TimeoutError {te}"
+
                 timeoutSignals.append(
                     {
                         "counter": counter,
@@ -95,6 +106,11 @@ def processSignals(filename, basename, uuid, target, signalsMetadata, blackliste
                 continue
             except Exception as e:
                 print(f"Exception for {counter} - {signalsMetadata[counter]['name']}: {e}")
+
+                signalsMetadata[counter]["signal_decoded_status"] = False
+                signalsMetadata[counter]["records_count"] = 0
+                signalsMetadata[counter]["message"] = f"Exception {e}"
+
                 errorSignals.append(
                     {
                         "counter": counter,

--- a/mdf42adx/MetadataTools.py
+++ b/mdf42adx/MetadataTools.py
@@ -24,7 +24,7 @@ def dumpSignals(filename):
 
     return counter
 
-def writeMetadata(filename, basename, uuid, target):
+def calculateMetadata(filename, basename, uuid):
     '''
         Creates an object containing the signals description for the MDF-4 file and writes it as a JSON file.
         It returns an array with the signal description for further processing.        
@@ -39,60 +39,64 @@ def writeMetadata(filename, basename, uuid, target):
     '''
 
     mdf = MDF(filename)
+    
+    print(f"Generating metadata file {basename}-{uuid}")
 
-    with open(os.path.join(target, f"{basename}-{uuid}.metadata.json"), 'w') as metadataFile:
-        
-        print(f"Writing metadata file {basename}-{uuid}")
+    metadata = {
+        "name": basename,
+        "source_uuid": str(uuid),
+        "preparation_startDate": str(datetime.utcnow()),
+        "signals": [],
+        "signals_comment": [],
+        "signals_decoding": [],
+        "group_comment": [],
+        "comments": mdf.header.comment,
+    }
+    
+    for signal in mdf.iter_channels(raw=True):
 
-        metadata = {
-            "name": basename,
-            "source_uuid": str(uuid),
-            "preparation_startDate": str(datetime.utcnow()),
-            "signals": [],
-            "signals_comment": [],
-            "signals_decoding": [],
-            "group_comment": [],
-            "comments": mdf.header.comment,
-        }
-        
-        for signal in mdf.iter_channels(raw=True):
+        source_name, source_type, bus_type, channel_group_acq_name, acq_source_name, acq_source_path, channel_group_acq_source_comment, channel_group_comment, signal_source_path = getSource(mdf, signal)
 
-            source_name, source_type, bus_type, channel_group_acq_name, acq_source_name, acq_source_path, channel_group_acq_source_comment, channel_group_comment, signal_source_path = getSource(mdf, signal)
+        metadata["signals"].append(
+            {
+                "name": signal.name,
+                "unit": signal.unit,
+                "group_index": signal.group_index,
+                "channel_index": signal.channel_index,
+                "channel_group_acq_name": channel_group_acq_name,
+                "acq_source_name": acq_source_name,
+                "acq_source_path": acq_source_path,
+                "source" : source_name,
+                "source_type": source_type,
+                "bus_type": bus_type,
+                "datatype": signal.samples.dtype.name,
+                "signal_source_path": signal_source_path,
+            }          
+        )
 
-            metadata["signals"].append(
-                {
-                    "name": signal.name,
-                    "unit": signal.unit,
-                    "group_index": signal.group_index,
-                    "channel_index": signal.channel_index,
-                    "channel_group_acq_name": channel_group_acq_name,
-                    "acq_source_name": acq_source_name,
-                    "acq_source_path": acq_source_path,
-                    "source" : source_name,
-                    "source_type": source_type,
-                    "bus_type": bus_type,
-                    "datatype": signal.samples.dtype.name,
-                    "signal_source_path": signal_source_path,
-                }          
-            )
+        metadata["signals_comment"].append(signal.comment)
 
-            metadata["signals_comment"].append(signal.comment)
+        metadata["signals_decoding"].append(str(signal.conversion))
 
-            metadata["signals_decoding"].append(str(signal.conversion))
-
-            metadata["group_comment"].append(
-                {
-                    "channel_group_acq_source_comment": channel_group_acq_source_comment,
-                    "channel_group_comment": channel_group_comment
-                }
-            )
-
-        metadataFile.write(json.dumps(metadata))
-       
-    print(f"Finished writing metadata file {basename}-{uuid} with {len(metadata['signals'])} signals")
+        metadata["group_comment"].append(
+            {
+                "channel_group_acq_source_comment": channel_group_acq_source_comment,
+                "channel_group_comment": channel_group_comment
+            }
+        )
+   
+    print(f"Finished calculating metadata {basename}-{uuid} with {len(metadata['signals'])} signals")
 
     mdf.close()
 
     del mdf
 
-    return metadata["signals"]
+    return metadata
+
+def writeMetadata(metadata, basename, uuid, target):
+    '''
+       Writes the metadata file to disk. 
+    '''
+    with open(os.path.join(target, f"{basename}-{uuid}.metadata.json"), 'w') as metadataFile:
+        metadataFile.write(json.dumps(metadata))
+        print(f"Finished writing metadata file {basename}-{uuid} with {len(metadata['signals'])} signals")


### PR DESCRIPTION
Made the following changes:
- Split the MetadataTools method into calculateMetadata and writeMetadata
- Now calculateMetadata returns the full metadata file
- After iterating over a signal, the metadata object is updated with the decoded status, the record count and the message
- The metadata is written at the end

Tested also the error case by generating exceptions. These get also logged as False, with count 0 and the description of the exception